### PR TITLE
Add header slot to support custom header layouts; simplify markup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,8 @@
     "material design",
     "expansion",
     "panel",
-	"collapse",
-	"collapsible"
+    "collapse",
+    "collapsible"
   ],
   "license": "Apache 2",
   "homepage": "https://github.com/collaborne/paper-expansion-panel",
@@ -26,7 +26,8 @@
     "iron-collapse": "PolymerElements/iron-collapse#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "paper-item": "PolymerElements/paper-item#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "iron-flex-layout": "^1.3.7"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,11 +6,16 @@
 		<link rel="import" href="../../iron-icons/iron-icons.html">
 		<link rel="import" href="../../paper-item/paper-item.html">
 		<link rel="import" href="../paper-expansion-panel.html">
+		<link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
+		<link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
+
 	</head>
 
 	<body>
 		<demo-snippet>
 			<template is="dom-bind">
+				<style is="custom-style" include="iron-flex"></style>
+
 				<paper-expansion-panel header="Item 1 (no summary)" opened>
 					Lots of very interesting content.
 				</paper-expansion-panel>
@@ -34,6 +39,27 @@
 						</paper-item-body>
 					</paper-item>
 				</paper-expansion-panel>
+				<paper-expansion-panel opened={{opened}}>
+					<iron-icon slot=header icon=bug-report
+						style='color: red; margin-right: 16px'></iron-icon>
+					<div slot=header class=flex style='font-weight: bold'>
+						Item 4
+					</div>
+					<div slot=header class=flex style='color: grey' hidden$=[[opened]]>
+						Custom header slot
+					</div>
+					<div>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+						convallis felis fringilla, scelerisque augue eget, finibus sapien.
+						Aliquam erat volutpat. Morbi libero urna, vestibulum sed facilisis
+						id, sodales id lectus. Sed condimentum molestie ligula, sed posuere
+						purus congue vitae. Nulla non augue velit. Aliquam in magna ac leo
+						tincidunt ullamcorper et sit amet erat. Fusce sit amet posuere diam.
+						Nunc scelerisque purus nisi, a faucibus est convallis eget. Donec
+						interdum ullamcorper gravida. In hendrerit iaculis mi consectetur
+						vestibulum. Proin eget tortor est. Proin imperdiet lectus et gravida
+						tincidunt.
+					</div>
 			</template>
 
 			<script>

--- a/paper-expansion-panel.html
+++ b/paper-expansion-panel.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-item/paper-item-body.html">
 <link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 A Material Design [expansion panel with header and collapsible content](https://material.google.com/components/expansion-panels.html)
@@ -37,8 +38,8 @@ Custom property | Description | Default
 			.header {
 				min-height: 48px;
 				color: var(--primary-text-color);
-				@apply --layout-horizontal;
-				@apply --layout-center-center;
+				@apply --layout-center;
+				@apply --layout-justified;
 				@apply --paper-font-subhead;
 				@apply --paper-expansion-panel-header;
 			}
@@ -56,22 +57,26 @@ Custom property | Description | Default
 				color: var(--secondary-text-color);
 				@apply --paper-expansion-panel-summary;
 			}
-			
+
 			.flex {
 				@apply --layout-flex;
 			}
 		</style>
 
-		<paper-item>
-			<paper-item-body>
-				<div class="header flex" on-tap="_toggleOpened">
-					<div class="flex">[[header]]</div>
-					<template is="dom-if" if="[[summary]]">
-						<div hidden$="[[opened]]" class="flex summary">[[summary]]</div>
-					</template>
-					<paper-icon-button class="toggle" icon="[[_toggleIcon]]"></paper-icon-button>
-				</div>
-			</paper-item-body>
+		<paper-item class=header on-tap="_toggleOpened">
+			<template is="dom-if" if="[[header]]">
+				<div class=flex>[[header]]</div>
+
+				<template is="dom-if" if="[[summary]]">
+					<div hidden$="[[opened]]" class="flex summary">[[summary]]</div>
+				</template>
+			</template>
+
+			<template is="dom-if" if="[[!header]]">
+					<slot name=header><div style='flex-grow: 1'>&nbsp;</div></slot>
+			</template>
+
+			<paper-icon-button class="toggle" icon="[[_toggleIcon]]"></paper-icon-button>
 		</paper-item>
 		<iron-collapse class="content" opened="{{opened}}">
 			<slot></slot>
@@ -90,7 +95,10 @@ Custom property | Description | Default
 			/**
 			 * Text in the header row
 			 */
-			header: String,
+			header: {
+				type: String,
+				value: '',
+			},
 
 			/**
 			 * Summary of the expandible area


### PR DESCRIPTION
This change adds a `header` slot which overrides the default header layout and allows full customization. The horizontal flexbox container is retained and the caret remains the last element.

This change also simplifies the markup somewhat by eliminating the paper-item-body and nested div from the header. paper-item is already a horizontal flexbox container, whereas paper-item-body is a vertical flexbox container, which unnecessarily increases complexity by requiring yet another horizontal flex container inside it (the unnecessary div).

Example provided.

Justification: We wanted to be able to customize the header layout. There are several different layout examples given at https://material.io/guidelines/components/expansion-panels.html#expansion-panels-usage currently. 

This change is backwards compatible with the existing API.